### PR TITLE
fix: corrects type of file path

### DIFF
--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -20,7 +20,7 @@ export interface FileSelectResult {
   /**
    * File Path
    */
-  path: boolean;
+  path: string;
   /**
    * File Name
    */


### PR DESCRIPTION
Hi there, thanks for your plugin!
It's working well so far but I saw that the type of the `path` is not correct.